### PR TITLE
Fix two small bugs

### DIFF
--- a/FastGarblingFourToTwoNoAssumptions.cpp
+++ b/FastGarblingFourToTwoNoAssumptions.cpp
@@ -352,7 +352,7 @@ void FastGarblingFourToTwoNoAssumptions::initAesEncryptionsAndInputKeys(block* e
 	for (int i = 0; i<numberOfInputs; i++){
 
 		emptyBothInputKeys[2 * i] = encryptedChunkKeys[2 * i];
-		emptyBothInputKeys[2 * i] = encryptedChunkKeys[2 * i + 1];
+		emptyBothInputKeys[2 * i + 1] = encryptedChunkKeys[2 * i + 1];
 
 		setSignalBit(&(emptyBothInputKeys[2 * i]), &(emptyBothInputKeys[2 * i + 1]));
 

--- a/GarbledBooleanCircuit.h
+++ b/GarbledBooleanCircuit.h
@@ -298,7 +298,9 @@ public:
 		*
 		*Sets the signal of wire1 to be the complement of wire0.
 		*/
-		void setSignalBit(block *wire0, block *wire1){ *((unsigned char *)(wire1)) = *((unsigned char *)(wire0)) ^ 1; };
+		void setSignalBit(block *wire0, block *wire1){
+            *((unsigned char *)(wire1)) = *((unsigned char *)(wire1)) & 0xFE ^ (*((unsigned char *)(wire0)) & 0x01);
+        };
 
 		
 		/*


### PR DESCRIPTION
Fix following two problems:

-  in initAesEncryptionsAndInputKeys, emptyBothInputKeys[2 * i] is
assigned twice instead of emptyBothInputKeys[2 * i] and
emptyBothInputKeys[2 * i+1]
- in setSignalBit, instead of only setting the most significant bit, the
whole byte is copied from wire0 to wire1